### PR TITLE
Update git clone link in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project was bootstrapped with [Vue CLI](https://cli.vuejs.org/)
 ## Getting started
 1. [Clone this repository](https://help.github.com/articles/cloning-a-repository/) using the [GitHub Command line tool](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and navigate into the downloaded directory.
     ```sh
-    git clone https://github.com/SAP/ui5-webcomponents-sample-vue.git
+    git clone https://github.com/SAP-samples/ui5-webcomponents-sample-vue.git
     cd ui5-webcomponents-sample-vue
     ```
 1. Install all dependencies


### PR DESCRIPTION
The link in the git clone command was out of date. I have replaced it with the one that works.